### PR TITLE
Change statusPrinter to statusWriter

### DIFF
--- a/cmd/helm/get_all.go
+++ b/cmd/helm/get_all.go
@@ -59,7 +59,7 @@ func newGetAllCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				return tpl(template, data, out)
 			}
 
-			return output.Table.Write(out, &statusPrinter{res, true, false})
+			return output.Table.Write(out, &statusWriter{res, true, false})
 		},
 	}
 

--- a/cmd/helm/install.go
+++ b/cmd/helm/install.go
@@ -122,7 +122,7 @@ func newInstallCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				return err
 			}
 
-			return outfmt.Write(out, &statusPrinter{rel, settings.Debug, false})
+			return outfmt.Write(out, &statusWriter{rel, settings.Debug, false})
 		},
 	}
 

--- a/cmd/helm/release_testing.go
+++ b/cmd/helm/release_testing.go
@@ -61,7 +61,7 @@ func newReleaseTestCmd(cfg *action.Configuration, out io.Writer) *cobra.Command 
 				return runErr
 			}
 
-			if err := outfmt.Write(out, &statusPrinter{rel, settings.Debug, false}); err != nil {
+			if err := outfmt.Write(out, &statusWriter{rel, settings.Debug, false}); err != nil {
 				return err
 			}
 

--- a/cmd/helm/status.go
+++ b/cmd/helm/status.go
@@ -70,7 +70,7 @@ func newStatusCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 			// strip chart metadata from the output
 			rel.Chart = nil
 
-			return outfmt.Write(out, &statusPrinter{rel, false, client.ShowDescription})
+			return outfmt.Write(out, &statusWriter{rel, false, client.ShowDescription})
 		},
 	}
 
@@ -95,21 +95,21 @@ func newStatusCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 	return cmd
 }
 
-type statusPrinter struct {
+type statusWriter struct {
 	release         *release.Release
 	debug           bool
 	showDescription bool
 }
 
-func (s statusPrinter) WriteJSON(out io.Writer) error {
+func (s statusWriter) WriteJSON(out io.Writer) error {
 	return output.EncodeJSON(out, s.release)
 }
 
-func (s statusPrinter) WriteYAML(out io.Writer) error {
+func (s statusWriter) WriteYAML(out io.Writer) error {
 	return output.EncodeYAML(out, s.release)
 }
 
-func (s statusPrinter) WriteTable(out io.Writer) error {
+func (s statusWriter) WriteTable(out io.Writer) error {
 	if s.release == nil {
 		return nil
 	}

--- a/cmd/helm/upgrade.go
+++ b/cmd/helm/upgrade.go
@@ -115,7 +115,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 					if err != nil {
 						return err
 					}
-					return outfmt.Write(out, &statusPrinter{rel, settings.Debug, false})
+					return outfmt.Write(out, &statusWriter{rel, settings.Debug, false})
 				} else if err != nil {
 					return err
 				}
@@ -160,7 +160,7 @@ func newUpgradeCmd(cfg *action.Configuration, out io.Writer) *cobra.Command {
 				fmt.Fprintf(out, "Release %q has been upgraded. Happy Helming!\n", args[0])
 			}
 
-			return outfmt.Write(out, &statusPrinter{rel, settings.Debug, false})
+			return outfmt.Write(out, &statusWriter{rel, settings.Debug, false})
 		},
 	}
 


### PR DESCRIPTION
The struct satisfies the Writer interface and should therefore be named
accordingly. Almost all other structs that satisfy the interface have
the .*Writer name.

Signed-off-by: Kristinn Björgvin Árdal <kristinnardalsecondary@gmail.com>

**If applicable**:
- [ ] this PR contains documentation
- [ ] this PR contains unit tests
- [x] this PR has been tested for backwards compatibility
